### PR TITLE
marks.lua: fix removal of marks

### DIFF
--- a/lua/harpoon/mark.lua
+++ b/lua/harpoon/mark.lua
@@ -230,10 +230,6 @@ function M.remove_empty_tail(_emit_on_changed)
 
     for i = M.get_length(), 1, -1 do
         local filename = M.get_marked_file_name(i)
-        if filename ~= "" then
-            return
-        end
-
         if filename == "" then
             table.remove(config.marks, i)
             found = found or _emit_on_changed


### PR DESCRIPTION
Ensure the mark is removed from the list upon M.rm_file. previously the mark was set to "", but not removed from the list.
